### PR TITLE
Appengine vs cloudrun/update 20250428

### DIFF
--- a/articles/appengine-vs-cloudrun.md
+++ b/articles/appengine-vs-cloudrun.md
@@ -71,11 +71,6 @@ App Engine for Go はスピンアップタイムが爆速なので、ここは A
 App Engine は最新の Version から 1つか２つぐらい遅れるが、幸い Go は後方互換を大事にする文化なので、むちゃくちゃ困ってはいない。
 Cloud Run だと コマンドラインツール で提供されているものも動かせることの方が嬉しいかもしれない。
 
-### 認証
-
-[Identity Aware Proxy](https://cloud.google.com/iap) を使う場合、Cloud Runは [Serverless NEG](https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts?hl=en) が必要となるため、完全無料ではできない。
-完全無料を目指していない場合は、App EngineとCloud Runでどちらを選択するかに影響するような差はない。
-
 ### Static Contents
 
 App Engine には Static Contents Server があるので、html, js などを配信するのはとても簡単だけど、Cloud Run にはそういった機能はないので、何かしら考えてやる必要がある。

--- a/articles/appengine-vs-cloudrun.md
+++ b/articles/appengine-vs-cloudrun.md
@@ -115,18 +115,18 @@ Cloud Run 自体の Deadline は 60min だが、Cloud Run に Request を送る�
 
 App Engine と Cloud Run をやりたいことに合わせてMixして使うのも結構強力だ。
 それができる機能として [Serverless NEG](https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts) がある。
-Serverless NEG はざっくり言うと [External HTTP(S) Load Balancing](https://cloud.google.com/load-balancing/docs/https?hl=en) の後ろに App Engine, Cloud Run, Cloud Functions を持ってこれるサービス。
+Serverless NEG はざっくり言うと [External Application Load Balancing](https://cloud.google.com/load-balancing/docs/https?hl=en) の後ろに App Engine, Cloud Run, Cloud Functions を持ってこれるサービス。
 Google Cloud Customer Engineer の Seiji Ariga さんが [噛み砕いた記事](https://medium.com/google-cloud-jp/serverless-neg-%E3%81%A7%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E9%96%8B%E7%99%BA%E3%82%92%E3%82%88%E3%82%8A%E6%9F%94%E8%BB%9F%E3%81%AB-4f9cebd2780f) を書いてくれている。
 Path ごとに向き先を設定できるので、 `/api/*` は App Engine `/image/upload` はマシンスペックを大きくした Cloud Run に送ることができる。
 
-更に External HTTP(S) Load Balancing が前にいれば、 [Cloud Armor](https://cloud.google.com/armor) が使えたり、Tokyo Region の [App Engine, Cloud Run に Custom Domain を割り当てた時に遅くなる問題](https://cloud.google.com/appengine/docs/standard/go/mapping-custom-domains?hl=en) が解決されるなど良いことが多い。
+更に External Application Load Balancing が前にいれば、 [Cloud Armor](https://cloud.google.com/armor) が使えたり、Tokyo Region の [App Engine, Cloud Run に Custom Domain を割り当てた時に遅くなる問題](https://cloud.google.com/appengine/docs/standard/go/mapping-custom-domains?hl=en) が解決されるなど良いことが多い。
 
 Severless NEGを使う場合、App EngineやCloud Runをそのまま使うのに比べて [制限事項](https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts?hl=en#limitations) があるので、一通り確認しておいた方がよい。
 1 Projectでのシンプルな構成であれば問題なるものは少ないと思うが、複雑なことをやろうとしている場合、制限に引っかかるものがあるかもしれない。
 
 Cloud Tasks, Cloud Pub/SubなどからのRequestをどこに送るのか？というのも少し気にする必要がある。
-自分はHTTP LB経由ではなく直接App EngineやCloud Runに送ることが多い。
-HTTP LBを経由する必要性をあまり感じないからだ。
+自分はLB経由ではなく直接App EngineやCloud Runに送ることが多い。
+LBを経由する必要性をあまり感じないからだ。
 
 # 余談
 


### PR DESCRIPTION
* [Cloud Runが単独でIAPに対応したので、App Engineと差はなくなった](https://github.com/sinmetal/zenn/commit/600dcde0fea64eba30d9b8c97d01d85605bbdb52)
* [LBの名前を更新](https://github.com/sinmetal/zenn/commit/606eccec2d1548f3950be844f52f9deba0e22a58)