### PR TITLE
CloudRunのアップデートを反映

### DIFF
--- a/articles/appengine-vs-cloudrun.md
+++ b/articles/appengine-vs-cloudrun.md
@@ -15,7 +15,6 @@ App Engineを使うのは、Landing Pageのようなあまり複雑なことを�
 
 この先は2つを比べて、僕がどちらを使うのかを判断する時の材料を書いていく。
 App Engine には Standard と Flex があるが、この記事では Standard を主に扱っている。
-Cloud Run には fully managed と for Anthos があるが、この記事では fully managed を主に扱っている。
 
 # App Engine と Cloud Run を比べてみる
 
@@ -57,7 +56,7 @@ App Engine は Deploy ([gcloud app deploy](https://cloud.google.com/sdk/gcloud/r
 開発環境だと CI でとりあえず main branch に merge されたら、Deploy したりするけど、Deploy を Skip してもよいような時でも CI 回してると Deploy を待つことになって、ちょっとめんどうに感じる。
 更にこの仕組みは成果物は Deploy しないと生まれないので、CI と CDを分離しづらい。
 
-Cloud Run は [Container Registry](https://cloud.google.com/container-registry) and [Artifact Registry](https://cloud.google.com/artifact-registry) の Container Image を Deploy できるので、App Engine より短い時間で CI を完了できる。
+Cloud Run は [Artifact Registry](https://cloud.google.com/artifact-registry) の Container Image を Deploy できるので、App Engine より短い時間で CI を完了できる。
 Container Image を作ってさえおけば、Deploy は簡単にできるので、CI と CD を分離しやすい。
 
 ### スピンアップタイム
@@ -137,32 +136,3 @@ App Engine 自体が Google Cloud Platform より昔から存在していたこ�
 
 Cloud Runに実装された双方向ストリーミングや WebSocketは、App Engineに要望はあったけど、実現されなかったものです。
 App Engine Image Service など Web Application を作る上で便利で安価なサービスが詰まっていた Platform としての App Engine は失われていくけど、時代に合わせて進化していくGCPが来年も楽しみです。
-
-# Cloud Functions は？
-
-ここまで読んだ読者の中には、Serverless には [Cloud Functions](https://cloud.google.com/functions) もあるけど・・・？と思っている方もいるでしょう。
-現状、僕はあまりCloud Functionsを使うことがありません。
-まず、Cloud Functions は Web Application を作るのには適しません。
-1 Instance 1 Function なので 10 API 作ろうと 10 Function Deployすることになり、アクセス権の制御など下回りの共通処理の UPDATE を考えると Deploy 祭りになってしまうのもつらいところです。
-1 Instance で同時に処理する Request は 1 なのも大人数が同時に利用し、1画面開くと同じユーザから複数 Request が実行される Web Application 向きではありません。
-
-そのため、Cloud Functions に向いてるのはユーザからの Request より、独立したイベント処理です。
-例えば、画像が新しくアップロードされたイベントから、サムネイルを作るとか、cron で 30秒毎にキャッシュを作っておくなどの処理です。
-ただ、これらの処理は App Engine や Cloud Run を使ってもできる処理なので、あまり Cloud Functions に分けておこうというモチベーションはありません。
-
-更に僕の場合、Go がメインですが、Go だと Dockerfile 書くのも簡単だし、main 関数で Web Server を立ち上げるのも簡単です。
-Cloud Run に簡単に乗せられるので、Cloud Run に寄せておきたい気持ちになります。
-そんな感じで、僕の場合は Cloud Functions を使う理由がないので、今のところほとんど使っていません。
-
-## Cloud Functions にしかできないこと
-
-Cloud Functions を選択するケースとして、Cloud Functions にしかない [Event Trigger](https://cloud.google.com/functions/docs/calling) を使うケースがあります。
-
-* Cloud Firestore Trigger
-* Google Analytics for Firebase Triggers
-* Firebase Realtime Database Triggers
-* Firebase Authentication Triggers
-* Firebase Remote Config Triggers
-
-これらの Trigger は Cloud Functions にしかないので、選択肢がありません。
-ただ、 [Event Trigger も Cloud Run が追いかけてる](https://cloud.google.com/blog/products/serverless/build-event-driven-applications-in-cloud-run) ので、Cloud Run 側の対応が進めば、好きな方を選べるようになりそうです。


### PR DESCRIPTION
* Cloud Run for Anthosという名前は消えたので、削除
* Cloud FunctionsはCloud Run functionsにリネームされて、合体したので、比較対象にする人はいないだろうと思ったので、削除